### PR TITLE
Subclass ZopeTestCase.Functional

### DIFF
--- a/plone/app/customerize/tests/testDocTests.py
+++ b/plone/app/customerize/tests/testDocTests.py
@@ -9,8 +9,10 @@ from plone.testing.z2 import Browser
 from plone.app.customerize.testing import \
     PLONE_APP_CUSTOMERIZE_FUNCTIONAL_TESTING
 
+from Testing.ZopeTestCase import Functional
 
-class CustomerizeFunctionalTestCase(TestCase):
+
+class CustomerizeFunctionalTestCase(TestCase, Functional):
 
     layer = PLONE_APP_CUSTOMERIZE_FUNCTIONAL_TESTING
 


### PR DESCRIPTION
If not you get a warning and it adds it anyway.

Fixes https://github.com/plone/Products.CMFPlone/issues/502