### PR TITLE
Fixed tests when run with zope.component 5+.

### DIFF
--- a/news/500.bugfix
+++ b/news/500.bugfix
@@ -1,0 +1,2 @@
+Fixed tests when run with ``zope.component`` 5+.
+[maurits]

--- a/plone/app/customerize/tests/testBrowserLayers.txt
+++ b/plone/app/customerize/tests/testBrowserLayers.txt
@@ -20,6 +20,10 @@ product is installed, we cannot view the view, though:
   >>> browser.handleErrors = False
   >>> browser.addHeader('Authorization', 'Basic %s:%s' % (
   ...     SITE_OWNER_NAME, SITE_OWNER_PASSWORD))
+
+First open the site root.  This avoids a crazy testing-only error with zope.component 5.
+
+  >>> browser.open('http://nohost/plone/')
   >>> browser.open('http://nohost/plone/@@layer-test-view')
   Traceback (most recent call last):
   ...


### PR DESCRIPTION
See https://github.com/plone/plone.app.users/pull/107